### PR TITLE
Add URI component decoding to the file identifier to support filenames with special characters

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -304,7 +304,7 @@
 					_$diffSections.hide();
 
 					// Show the selected section
-					var sectionId = fileIdentifier.replace('#', '').replace(/%20/g, ' ');
+					var sectionId = decodeURIComponent(fileIdentifier.replace('#', ''));
 					var $section = $('section[id*="' + sectionId + '"]');
 					$section.show();
 


### PR DESCRIPTION
I ran into an issue with one of my projects where we have several files with special characters in the filenames, particularly `+` and `@` characters, and when using Diff Tree, selecting the filename of files with special characters wouldn't load the diff.

I initially started by just appending the special characters that I need to the string replacements:

```
var sectionId = fileIdentifier.replace('#', '').replace(/%20/g, ' ').replace(/%2B/g, '+').replace(/%40/g, '@');
```

But then realized that we could use `decodeURIComponent` to cover all special characters.