### PR TITLE
 decodeURI(folder)

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -395,7 +395,7 @@
 					var item = tempObject.children[folder];
 
 					if (!item) {
-						item = tempObject.children[folder] = new TreeNodeModel(folder, index + 1);
+						item = tempObject.children[folder] = new TreeNodeModel(decodeURI(folder), index + 1);
 
 						if (index === maxLevel - 1) {
 							tempObject.data.fileCount++;


### PR DESCRIPTION
decodeURL can help Non-English files show friendly name in the tree.
Example:
https://i.imgur.com/ojO791g.jpg

I come from Taiwan , sometimes we have files named by Traditional Chinese
My teams need this feature 
Thank you